### PR TITLE
removing spinner from bottom of featured post

### DIFF
--- a/components/grids/FeaturedPresentationalGrid.vue
+++ b/components/grids/FeaturedPresentationalGrid.vue
@@ -11,9 +11,6 @@
         <slot :item="item"></slot>
       </div>
     </div>
-    <div v-if="bottomLoader" class="loading-posts">
-      <loading-spinner />
-    </div>
     <intersection-observer @view="$emit('atEnd')" />
   </div>
 </template>


### PR DESCRIPTION
No more distracting spinner in the middle of the page for ~5 seconds upon loading.