### PR TITLE
adding field to cms template for figure captions

### DIFF
--- a/cms/netlify/static/admin/config.yml
+++ b/cms/netlify/static/admin/config.yml
@@ -21,6 +21,7 @@ collections:
       - {label: "Author", name: "author", widget: "string", default: "Derp Bot"}
       - {label: "Publish Date", name: "date", widget: "datetime"}
       - {label: "Featured Image", name: "featureImage", widget: "image"}
+      - {label: "Image Caption", name: "imageCaption", widget: "string"}
       - {label: "Body", name: "body", widget: "markdown"}
   - name: "categories"
     label: "Categories"


### PR DESCRIPTION
Adding field in the cms interface for a picture caption. It won't be used in pages at all yet. This is just anticipating future changes to the post pages' layouts. You never know, we might want it eventually.